### PR TITLE
Include roots as example build tool

### DIFF
--- a/articles/assembling-your-static-app-stack.md
+++ b/articles/assembling-your-static-app-stack.md
@@ -38,7 +38,7 @@ while others can be used for just about any application you might build. When ch
 tool, it makes sense to find something that fits your workflow, is actively maintained, and
 has an active user community.
 
-**Examples:** [Jekyll](http://jekyllrb.com/), [Grunt](http://gruntjs.com/), [Yeoman](http://yeoman.io/), [Harp](http://harpjs.com/)
+**Examples:** [Jekyll](http://jekyllrb.com/), [Grunt](http://gruntjs.com/), [Yeoman](http://yeoman.io/), [Harp](http://harpjs.com/), [Roots](http://roots.cx/)
 
 ### Package Managers
 


### PR DESCRIPTION
Since this was open source, I figured it was worth a shot seeing if you'd include our build tool of choice in the list - [Roots](http://roots.cx/)
